### PR TITLE
enhance circle-ci configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,10 @@ jobs:
       - run:
           name: Build learning locker image
           command: |
+            source ./.circleci/releases.sh
             docker build \
               -t fundocker/learninglocker:${CIRCLE_SHA1} \
+              --build-arg LL_VERSION="${LEARNINGLOCKER_VERSION}" \
               learninglocker/
 
       - run:
@@ -72,8 +74,10 @@ jobs:
       - run:
           name: Build xapi-service image
           command: |
+            source ./.circleci/releases.sh
             docker build \
               -t fundocker/xapi-service:${CIRCLE_SHA1} \
+              --build-arg VERSION="${XAPI_VERSION}" \
               xapi/
 
       - run:

--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v2.6.2"
+export LEARNINGLOCKER_VERSION="v2.6.3"
 export XAPI_VERSION="v2.2.15"

--- a/learninglocker/Dockerfile
+++ b/learninglocker/Dockerfile
@@ -9,7 +9,7 @@ FROM node:8-jessie-slim
 #   -t learninglocker:v2.6.2 \
 #   .
 #
-ARG LL_VERSION="v2.6.2"
+ARG LL_VERSION
 
 RUN mkdir /app \
     && chown node. /app

--- a/xapi/Dockerfile
+++ b/xapi/Dockerfile
@@ -1,7 +1,7 @@
 # xapi-service Dockerfile
 FROM node:8-jessie-slim as Builder
 
-ARG VERSION="v2.2.15"
+ARG VERSION
 
 RUN mkdir /app
 


### PR DESCRIPTION
## purpose

We have the version we want to build in `.circleci/releases.sh` file but we don't use it to build images.

Also, a new version of learning locker is available, it is out of the scope of this PR but the modification is small and I made it here.

## Proposal

- [x] Use version defined in `.circleci/releases.sh` to build images.
- [x] Upgrade version of learning locker to `v2.6.3`