### PR TITLE
🔖(learninglocker) bump version to v2.6.4

### DIFF
--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v2.6.3"
+export LEARNINGLOCKER_VERSION="v2.6.4"
 export XAPI_VERSION="v2.2.15"


### PR DESCRIPTION
version 2.6.4 is available. 

After updateing `releases.sh` file this version can be tagged.