### PR TITLE
🔖(learninglocker) bump version to v2.6.6

### DIFF
--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v2.6.5"
+export LEARNINGLOCKER_VERSION="v2.6.6"
 export XAPI_VERSION="v2.2.15"


### PR DESCRIPTION
https://github.com/LearningLocker/learninglocker/releases/tag/v2.6.6