### PR TITLE
🔖(xapi-service) bump version to v2.3.0

### DIFF
--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export LEARNINGLOCKER_VERSION="v2.7.0"
-export XAPI_VERSION="v2.2.15"
+export XAPI_VERSION="v2.3.0"


### PR DESCRIPTION
https://github.com/LearningLocker/xapi-service/releases/tag/v2.3.0