### PR TITLE
🔖(learninglocker) bump version to v2.8.0

### DIFF
--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v2.7.1"
+export LEARNINGLOCKER_VERSION="v2.8.0"
 export XAPI_VERSION="v2.3.0"


### PR DESCRIPTION
https://github.com/LearningLocker/learninglocker/releases/tag/v2.8.0