### PR TITLE
🔖(xapi-service) bump version to v2.5.4 and v2.5.5

### DIFF
--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export LEARNINGLOCKER_VERSION="v3.15.3"
-export XAPISERVICE_VERSION="v2.5.3"
+export XAPISERVICE_VERSION="v2.5.4"

--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export LEARNINGLOCKER_VERSION="v3.15.3"
-export XAPISERVICE_VERSION="v2.5.4"
+export XAPISERVICE_VERSION="v2.5.5"


### PR DESCRIPTION
https://github.com/LearningLocker/xapi-service/releases/tag/v2.5.4
https://github.com/LearningLocker/xapi-service/releases/tag/v2.5.5