### PR TITLE
New xAPI-service (2.7 to 2.9) & learning locker releases (4.4.x)

### DIFF
--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export LEARNINGLOCKER_VERSION="v4.4.4"
-export XAPISERVICE_VERSION="v2.8.0"
+export XAPISERVICE_VERSION="v2.9.0"

--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export LEARNINGLOCKER_VERSION="v4.4.4"
-export XAPISERVICE_VERSION="v2.7.0"
+export XAPISERVICE_VERSION="v2.8.0"

--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v4.4.3"
+export LEARNINGLOCKER_VERSION="v4.4.4"
 export XAPISERVICE_VERSION="v2.6.0"

--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v4.4.1"
+export LEARNINGLOCKER_VERSION="v4.4.2"
 export XAPISERVICE_VERSION="v2.6.0"

--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v4.4.0"
+export LEARNINGLOCKER_VERSION="v4.4.1"
 export XAPISERVICE_VERSION="v2.6.0"

--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export LEARNINGLOCKER_VERSION="v4.4.4"
-export XAPISERVICE_VERSION="v2.6.0"
+export XAPISERVICE_VERSION="v2.7.0"

--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v4.4.2"
+export LEARNINGLOCKER_VERSION="v4.4.3"
 export XAPISERVICE_VERSION="v2.6.0"


### PR DESCRIPTION
## xapi-service

* v2.7.0
* v2.8.0
* v2.9.0

## learninglocker

* v4.4.1
* v4.4.2
* v4.4.3
* v4.4.4
