### PR TITLE
🔖(learninglocker) bump version to v4.6.0

### DIFF
--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v4.5.0"
+export LEARNINGLOCKER_VERSION="v4.6.0"
 export XAPISERVICE_VERSION="v2.9.2"


### PR DESCRIPTION
https://github.com/LearningLocker/learninglocker/releases/tag/v4.6.0