### PR TITLE
Releases lrs 5.2 and xapi 2.9.10

### DIFF
--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v5.2.0"
+export LEARNINGLOCKER_VERSION="v5.2.1"
 export XAPISERVICE_VERSION="v2.9.9"

--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v5.1.0"
+export LEARNINGLOCKER_VERSION="v5.2.0"
 export XAPISERVICE_VERSION="v2.9.9"

--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v5.2.1"
+export LEARNINGLOCKER_VERSION="v5.2.2"
 export XAPISERVICE_VERSION="v2.9.9"

--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export LEARNINGLOCKER_VERSION="v5.2.2"
-export XAPISERVICE_VERSION="v2.9.9"
+export XAPISERVICE_VERSION="v2.9.10"


### PR DESCRIPTION
Learninglocker:

https://github.com/LearningLocker/learninglocker/releases/tag/v5.2.0
https://github.com/LearningLocker/learninglocker/releases/tag/v5.2.1
https://github.com/LearningLocker/learninglocker/releases/tag/v5.2.2

Xapi:

https://github.com/LearningLocker/xapi-service/releases/tag/v2.9.10