### PR TITLE
🔖(learninglocker) bump version to v6.0.1

### DIFF
--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v6.0.0"
+export LEARNINGLOCKER_VERSION="v6.0.1"
 export XAPISERVICE_VERSION="v3.0.0"


### PR DESCRIPTION
https://github.com/LearningLocker/learninglocker/releases/tag/v6.0.1