### PR TITLE
Add LL 6.0.x missing releases and xAPI 3.1.0

### DIFF
--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v6.0.5"
+export LEARNINGLOCKER_VERSION="v6.0.6"
 export XAPISERVICE_VERSION="v3.0.0"

--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v6.0.4"
+export LEARNINGLOCKER_VERSION="v6.0.5"
 export XAPISERVICE_VERSION="v3.0.0"

--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v6.0.2"
+export LEARNINGLOCKER_VERSION="v6.0.3"
 export XAPISERVICE_VERSION="v3.0.0"

--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v6.0.6"
+export LEARNINGLOCKER_VERSION="v6.0.7"
 export XAPISERVICE_VERSION="v3.0.0"

--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LEARNINGLOCKER_VERSION="v6.0.3"
+export LEARNINGLOCKER_VERSION="v6.0.4"
 export XAPISERVICE_VERSION="v3.0.0"


### PR DESCRIPTION
### Learning locker releases

* https://github.com/LearningLocker/learninglocker/releases/tag/v6.0.3
* https://github.com/LearningLocker/learninglocker/releases/tag/v6.0.4
* https://github.com/LearningLocker/learninglocker/releases/tag/v6.0.5
* https://github.com/LearningLocker/learninglocker/releases/tag/v6.0.6
* https://github.com/LearningLocker/learninglocker/releases/tag/v6.0.7
