### PR TITLE
🔖(xapi-service) bump version to v3.1.0

### DIFF
--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export LEARNINGLOCKER_VERSION="v6.0.7"
-export XAPISERVICE_VERSION="v3.0.0"
+export XAPISERVICE_VERSION="v3.1.0"

--- a/xapi/Dockerfile
+++ b/xapi/Dockerfile
@@ -17,7 +17,6 @@ RUN cd /tmp && curl --compressed -L -o "xapi-service-${VERSION}.tar.gz" "https:/
 
 # Install xapi-service
 RUN cd /app \
-    && rm package-lock.json \
     && yarn install --ignore-engines \
     && yarn build
 


### PR DESCRIPTION
## Proposal

New release: https://github.com/LearningLocker/xapi-service/releases/tag/v3.1.0

We've also removed the `package-lock.json` file removal instruction as it no longer exists in the original repository.