### PR TITLE
🔖(xapi-service) bump version to v3.1.1

### DIFF
--- a/.circleci/releases.sh
+++ b/.circleci/releases.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export LEARNINGLOCKER_VERSION="v6.0.7"
-export XAPISERVICE_VERSION="v3.1.0"
+export XAPISERVICE_VERSION="v3.1.1"


### PR DESCRIPTION
Release:

* https://github.com/LearningLocker/xapi-service/releases/tag/v3.1.1